### PR TITLE
[EDITOR] enable "delete-selection-mode" by default

### DIFF
--- a/lisp/init-editor.el
+++ b/lisp/init-editor.el
@@ -21,6 +21,7 @@
 	       scroll-conservatively 0
 	       scroll-preserve-screen-position nil))))
 
+(delete-selection-mode)
 
 (provide 'init-editor)
 


### PR DESCRIPTION
"C-d" should delete marked regions without having to enable "delete"selection-mode" manually.

Closes #2 